### PR TITLE
Correccion de accesos a array vacios y con indices inexistentes

### DIFF
--- a/TodoPago/lib/Utils/FraudControlValidator.php
+++ b/TodoPago/lib/Utils/FraudControlValidator.php
@@ -116,7 +116,7 @@ class FraudControlValidator {
 			$descs = explode("#", $desc);
 			$cant = count($descs);
 			if((254/$cant) < 19) {
-				foreach($descs as $d) {
+				foreach($descs as $i=>$d) {
 					$descs[$i] = $this->truncate($d, array(254/19));
 				}		
 				$aux = "";			
@@ -150,7 +150,7 @@ class FraudControlValidator {
 		$res = array();
 		if(count($arr) > $cant) {
 			for($i = 0; $i < $cant; $i++) {
-				$arr[$i] = $this->clean($res[$i]);
+				$arr[$i] = $this->clean($arr[$i]);
 				if($number) {
 					$res[$i] = $this->amount($arr[$i]);
 				} else {


### PR DESCRIPTION
En nuestro caso al tratar de crear una orden de pago con 14 items que poseían una descripción larga se obtenía: 

**E_NOTICE**: Undefined variable: i. Linea: 120
Cuando el método FraudControlValidator::getCsitCant() trata de truncar la descripción para adaptarse a la longitud permitida.

**E_NOTICE**: Undefined offset: 0. Linea 153
Cuando el método FraudControlValidator::csitFormat() trata de formatear los campos. En este caso el método trataba de acceder al indice de un array vacío.
